### PR TITLE
generic wording aroma warning notice

### DIFF
--- a/resin/res/i18n/en-us.ini
+++ b/resin/res/i18n/en-us.ini
@@ -110,7 +110,7 @@ listing.togglekeyboard = Toggle Keyboard
 listing.search = Search:
 listing.by = by
 listing.appletwarning = NOTICE: You are in Applet mode! Search "Switch Applet Mode" online for more info.
-listing.aromawarning = NOTICE: We recommend running as a WUHB not RPX, Google "Wii U Aroma" for more info.
+listing.aromawarning = NOTICE: We recommend running as a WUHB not RPX, search "Wii U Aroma" online for more info.
 listing.debugwarning = NOTICE: You are using a dev build! Update to a stable release if this is unintended.
 listing.earthday = Happy Earth Day!
 


### PR DESCRIPTION
Since #164 was merged, the aroma warning should also be changed for consistency.