### PR TITLE
Fix crash on exit caused by destroying curl after networking stack

### DIFF
--- a/gui/main.cpp
+++ b/gui/main.cpp
@@ -123,6 +123,13 @@ int main(int argc, char* argv[])
 		display->mainLoop();
 	}
 
+	// ~MainDisplay() -> ~RootDisplay -> DownloadQueue::quit -> ~DownloadQueue() -> curl_multi_cleanup()
+	// must be called *before* deinit_networking() -> socketExit().
+	// It's *probably* safe to not call deinit_networking() on exception, but that leaks resources
+	// (is it a problem? IDK).
+	display.reset();
+	// TODO catch-all and display a clean abort message or *anything* other than corrupting the stack
+
 	deinit_networking();
 
 	return 0;


### PR DESCRIPTION
For some reason, the download queue lives in the display object and owns a `CURLM` multi handle. When the display is destroyed, it calls `curl_multi_cleanup()`, which closes some network fds. If we call `deinit_networking() → socketExit()` before returning from main, then destroy the `MainDisplay` while returning, it closes a network fd and segfaults in libc `_close_r()`.

The easiest fix is to delete the display *before* uninitializing networking. An alternative is to move deinit_networking() into its own RAII destructor callback, but I didn't want to introduce new types into this project yet.